### PR TITLE
feat: 포인트 충전 메서드를 포인트 사용에도 이용하도록 메서드 수정

### DIFF
--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -43,7 +43,7 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return pointService.charge(id, amount);
+        return pointService.chargeOrUse(id, amount, TransactionType.CHARGE);
     }
 
     /**
@@ -54,6 +54,6 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.chargeOrUse(id, amount, TransactionType.USE);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -27,9 +27,9 @@ public class PointService {
 
 
     /**
-     * 특정유저의 포인트 충전
+     * 특정유저의 포인트 충전 및 사용
      */
-    public UserPoint charge(long id, long amount) {
+    public UserPoint chargeOrUse(long id, long amount, TransactionType type) {
         // user 검증 - 유저 id가 0 이하인 경우 오류 발생
         if (id <= 0) {
             throw new CustomException(ErrorCode.USER_ID_ERROR);
@@ -41,10 +41,10 @@ public class PointService {
         }
 
         // point history insert
-        pointHistoryTable.insert(id, amount, TransactionType.CHARGE, System.currentTimeMillis());
+        pointHistoryTable.insert(id, amount, type, System.currentTimeMillis());
 
         // userPoint update & return
         UserPoint userPoint = userPointTable.selectById(id);
-        return userPointTable.insertOrUpdate(id, userPoint.point() + amount);
+        return userPointTable.insertOrUpdate(id, userPoint.point() + amount * type.getSign());
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/TransactionType.java
+++ b/src/main/java/io/hhplus/tdd/point/TransactionType.java
@@ -1,11 +1,20 @@
 package io.hhplus.tdd.point;
 
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * 포인트 트랜잭션 종류
  * - CHARGE : 충전
  * - USE : 사용
  */
+@AllArgsConstructor
+@Getter
 public enum TransactionType {
-    CHARGE, USE
+    CHARGE(1),
+    USE(-1)
+    ;
+
+    private final int sign;
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -48,16 +48,17 @@ class PointServiceTest {
         // 특정유저의 id, 충전 금액
         long id = 0;
         long amount = 2000;
+        TransactionType type = TransactionType.CHARGE;
 
         // 충전시 오류발생
-        CustomException e = assertThrows(CustomException.class, () -> pointService.charge(id, amount));
+        CustomException e = assertThrows(CustomException.class, () -> pointService.chargeOrUse(id, amount, type));
 
         // 오류코드 검증
         assertEquals(ErrorCode.USER_ID_ERROR.getCode(), e.getErrorCode().getCode());
 
         // case2
         long id2 = -1;
-        CustomException e2 = assertThrows(CustomException.class, () -> pointService.charge(id2, amount));
+        CustomException e2 = assertThrows(CustomException.class, () -> pointService.chargeOrUse(id2, amount, type));
         assertEquals(ErrorCode.USER_ID_ERROR.getCode(), e2.getErrorCode().getCode());
     }
 
@@ -68,16 +69,17 @@ class PointServiceTest {
         // 특정유저의 id, 충전 금액
         long id = 1L;
         long amount = 0;
+        TransactionType type = TransactionType.CHARGE;
 
         // 충전시 오류발생
-        CustomException e = assertThrows(CustomException.class, () -> pointService.charge(id, amount));
+        CustomException e = assertThrows(CustomException.class, () -> pointService.chargeOrUse(id, amount, type));
 
         // 오류코드 검증
         assertEquals(ErrorCode.POINT_AMOUNT_ERROR.getCode(), e.getErrorCode().getCode());
 
         // case2
         long amount2 = -2000;
-        CustomException e2 = assertThrows(CustomException.class, () -> pointService.charge(id, amount2));
+        CustomException e2 = assertThrows(CustomException.class, () -> pointService.chargeOrUse(id, amount2, type));
         assertEquals(ErrorCode.POINT_AMOUNT_ERROR.getCode(), e2.getErrorCode().getCode());
     }
 
@@ -87,12 +89,13 @@ class PointServiceTest {
         // case1
         long id = 1L;
         long amount = 2000;
+        TransactionType type = TransactionType.CHARGE;
 
-        UserPoint userPoint = pointService.charge(id, amount);
+        UserPoint userPoint = pointService.chargeOrUse(id, amount, type);
         assertEquals(userPoint.point(), amount);
 
         // case2 (같은유저가 한번더 충전)
-        UserPoint userPoint2 = pointService.charge(id, amount);
+        UserPoint userPoint2 = pointService.chargeOrUse(id, amount, type);
         assertEquals(userPoint2.point(), 2 * amount);
     }
 


### PR DESCRIPTION
포인트 사용 메서드를 작업하던 중 충전 메서드와 기본적인 로직이 같다고 생각해 기존 충전메서드를 같이 이용할 수 있도록 수정했습니다. 

1. PointService.charge(id,  amount) 메서드에 TransactionType 파라미터 추가
2. 남는 UserPoint 금액 계산을 위해 TransactionType enum 클래스에 필드 추가
3. 기존 PointService.charge() 메서드 관련 테스트 수정