### PR TITLE
feat: 포인트 사용 테스트코드 추가, 포인트 충전/사용 내역 조회기능 구현 및 테스트

### DIFF
--- a/src/main/java/io/hhplus/tdd/database/PointHistoryTable.java
+++ b/src/main/java/io/hhplus/tdd/database/PointHistoryTable.java
@@ -1,7 +1,7 @@
 package io.hhplus.tdd.database;
 
 
-import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.entity.PointHistory;
 import io.hhplus.tdd.point.TransactionType;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/io/hhplus/tdd/database/UserPointTable.java
+++ b/src/main/java/io/hhplus/tdd/database/UserPointTable.java
@@ -1,6 +1,6 @@
 package io.hhplus.tdd.database;
 
-import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.entity.UserPoint;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -1,9 +1,9 @@
 package io.hhplus.tdd.point;
 
 import io.hhplus.tdd.CustomException;
-import io.hhplus.tdd.database.PointHistoryTable;
-import io.hhplus.tdd.database.UserPointTable;
 import io.hhplus.tdd.ErrorCode;
+import io.hhplus.tdd.point.repository.PointHistoryRepository;
+import io.hhplus.tdd.point.repository.UserPointRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PointService {
 
-    private final UserPointTable userPointTable;
-    private final PointHistoryTable pointHistoryTable;
+    private final UserPointRepository userPointRepository;
+    private final PointHistoryRepository pointHistoryRepository;
 
     /**
      * 특정유저의 포인트 조회
@@ -22,7 +22,7 @@ public class PointService {
         if (id <= 0) {
             throw new CustomException(ErrorCode.USER_ID_ERROR);
         }
-        return userPointTable.selectById(id);
+        return userPointRepository.selectById(id);
     }
 
 
@@ -41,10 +41,10 @@ public class PointService {
         }
 
         // point history insert
-        pointHistoryTable.insert(id, amount, type, System.currentTimeMillis());
+        pointHistoryRepository.insert(id, amount, type);
 
         // userPoint update & return
-        UserPoint userPoint = userPointTable.selectById(id);
-        return userPointTable.insertOrUpdate(id, userPoint.point() + amount * type.getSign());
+        UserPoint userPoint = this.userPointRepository.selectById(id);
+        return this.userPointRepository.insertOrUpdate(id, userPoint.point() + amount * type.getSign());
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/controller/PointController.java
@@ -1,5 +1,9 @@
-package io.hhplus.tdd.point;
+package io.hhplus.tdd.point.controller;
 
+import io.hhplus.tdd.point.entity.PointHistory;
+import io.hhplus.tdd.point.service.PointService;
+import io.hhplus.tdd.point.TransactionType;
+import io.hhplus.tdd.point.entity.UserPoint;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/hhplus/tdd/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/controller/PointController.java
@@ -36,7 +36,7 @@ public class PointController {
     public List<PointHistory> history(
             @PathVariable long id
     ) {
-        return List.of();
+        return pointService.findPointHistoriesByUserId(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/entity/PointHistory.java
+++ b/src/main/java/io/hhplus/tdd/point/entity/PointHistory.java
@@ -1,4 +1,6 @@
-package io.hhplus.tdd.point;
+package io.hhplus.tdd.point.entity;
+
+import io.hhplus.tdd.point.TransactionType;
 
 public record PointHistory(
         long id,

--- a/src/main/java/io/hhplus/tdd/point/entity/UserPoint.java
+++ b/src/main/java/io/hhplus/tdd/point/entity/UserPoint.java
@@ -1,4 +1,4 @@
-package io.hhplus.tdd.point;
+package io.hhplus.tdd.point.entity;
 
 public record UserPoint(
         long id,

--- a/src/main/java/io/hhplus/tdd/point/repository/PointHistoryRepo.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/PointHistoryRepo.java
@@ -1,7 +1,7 @@
 package io.hhplus.tdd.point.repository;
 
 import io.hhplus.tdd.database.PointHistoryTable;
-import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.entity.PointHistory;
 import io.hhplus.tdd.point.TransactionType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/io/hhplus/tdd/point/repository/PointHistoryRepo.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/PointHistoryRepo.java
@@ -1,0 +1,25 @@
+package io.hhplus.tdd.point.repository;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.TransactionType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PointHistoryRepo implements PointHistoryRepository {
+
+    private final PointHistoryTable pointHistoryTable;
+
+    @Override
+    public PointHistory insert(long userId, long amount, TransactionType type) {
+        return pointHistoryTable.insert(userId, amount, type, System.currentTimeMillis());
+    }
+
+    @Override
+    public List<PointHistory> selectAllByUserId(long userId) {
+        return pointHistoryTable.selectAllByUserId(userId);
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/repository/PointHistoryRepository.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/PointHistoryRepository.java
@@ -1,6 +1,6 @@
 package io.hhplus.tdd.point.repository;
 
-import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.entity.PointHistory;
 import io.hhplus.tdd.point.TransactionType;
 import java.util.List;
 import org.springframework.stereotype.Component;

--- a/src/main/java/io/hhplus/tdd/point/repository/PointHistoryRepository.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/PointHistoryRepository.java
@@ -1,0 +1,12 @@
+package io.hhplus.tdd.point.repository;
+
+import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.TransactionType;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface PointHistoryRepository {
+    PointHistory insert(long userId, long amount, TransactionType type);
+    List<PointHistory> selectAllByUserId(long userId);
+}

--- a/src/main/java/io/hhplus/tdd/point/repository/UserPointRepo.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/UserPointRepo.java
@@ -1,7 +1,7 @@
 package io.hhplus.tdd.point.repository;
 
 import io.hhplus.tdd.database.UserPointTable;
-import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.entity.UserPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/io/hhplus/tdd/point/repository/UserPointRepo.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/UserPointRepo.java
@@ -1,0 +1,23 @@
+package io.hhplus.tdd.point.repository;
+
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.point.UserPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserPointRepo implements UserPointRepository {
+
+    private final UserPointTable userPointTable;
+
+    @Override
+    public UserPoint selectById(Long id) {
+        return userPointTable.selectById(id);
+    }
+
+    @Override
+    public UserPoint insertOrUpdate(long id, long amount) {
+        return userPointTable.insertOrUpdate(id, amount);
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/repository/UserPointRepository.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/UserPointRepository.java
@@ -1,0 +1,12 @@
+package io.hhplus.tdd.point.repository;
+
+import io.hhplus.tdd.point.UserPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface UserPointRepository {
+
+    UserPoint selectById(Long id);
+    UserPoint insertOrUpdate(long id, long amount);
+
+}

--- a/src/main/java/io/hhplus/tdd/point/repository/UserPointRepository.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/UserPointRepository.java
@@ -1,6 +1,6 @@
 package io.hhplus.tdd.point.repository;
 
-import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.entity.UserPoint;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/io/hhplus/tdd/point/service/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/PointService.java
@@ -1,7 +1,9 @@
-package io.hhplus.tdd.point;
+package io.hhplus.tdd.point.service;
 
 import io.hhplus.tdd.CustomException;
 import io.hhplus.tdd.ErrorCode;
+import io.hhplus.tdd.point.TransactionType;
+import io.hhplus.tdd.point.entity.UserPoint;
 import io.hhplus.tdd.point.repository.PointHistoryRepository;
 import io.hhplus.tdd.point.repository.UserPointRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/io/hhplus/tdd/point/service/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/PointService.java
@@ -3,9 +3,11 @@ package io.hhplus.tdd.point.service;
 import io.hhplus.tdd.CustomException;
 import io.hhplus.tdd.ErrorCode;
 import io.hhplus.tdd.point.TransactionType;
+import io.hhplus.tdd.point.entity.PointHistory;
 import io.hhplus.tdd.point.entity.UserPoint;
 import io.hhplus.tdd.point.repository.PointHistoryRepository;
 import io.hhplus.tdd.point.repository.UserPointRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -48,5 +50,12 @@ public class PointService {
         // userPoint update & return
         UserPoint userPoint = this.userPointRepository.selectById(id);
         return this.userPointRepository.insertOrUpdate(id, userPoint.point() + amount * type.getSign());
+    }
+
+    /**
+     * 특정유저의 포인트 충전/사용 내역 조회
+     */
+    public List<PointHistory> findPointHistoriesByUserId(long userId) {
+        return pointHistoryRepository.selectAllByUserId(userId);
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -2,12 +2,15 @@ package io.hhplus.tdd.point;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.hhplus.tdd.CustomException;
 import io.hhplus.tdd.ErrorCode;
 import io.hhplus.tdd.point.repository.PointHistoryRepository;
 import io.hhplus.tdd.point.repository.UserPointRepository;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -102,18 +105,28 @@ class PointServiceTest {
     @Test
     @DisplayName("특정유저의 포인트 충전 성공케이스 테스트")
     void chargeUserPoint() {
-        // case1
         long id = 1L;
-        long amount = 2000L;
-        long existingPoint = 3000L;
-        when(userPointRepository.selectById(id))
-            .thenReturn(new UserPoint(id,existingPoint,System.currentTimeMillis()));
-        when(userPointRepository.insertOrUpdate(id,amount+existingPoint))
-            .thenReturn(new UserPoint(id,amount+existingPoint,System.currentTimeMillis()));
-        TransactionType type = TransactionType.CHARGE;
+        AtomicLong currentPoint = new AtomicLong(3000L); // 충전,사용 케이스 동시 테스트 위한 가변변수 선언.
 
-        UserPoint userPoint = pointService.chargeOrUse(id, amount, type);
+        when(userPointRepository.selectById(id))
+            .thenAnswer(invocation -> new UserPoint(id, currentPoint.get(), System.currentTimeMillis()));
+
+        when(userPointRepository.insertOrUpdate(eq(id),anyLong()))
+            .thenAnswer(invocation -> {
+                long updatedPoint = invocation.getArgument(1);
+                currentPoint.set(updatedPoint);
+                return new UserPoint(id,updatedPoint,System.currentTimeMillis());
+            });
+
+        // 충전케이스 테스트
+        long charge = 2000L;
+        UserPoint userPoint = pointService.chargeOrUse(id, charge, TransactionType.CHARGE);
         assertEquals(5000L, userPoint.point());
+
+        // 사용케이스 테스트
+        long use = 200L;
+        UserPoint userPoint2 = pointService.chargeOrUse(id, use, TransactionType.USE);
+        assertEquals(4800L,  userPoint2.point());
     }
 
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -8,10 +8,12 @@ import static org.mockito.Mockito.when;
 
 import io.hhplus.tdd.CustomException;
 import io.hhplus.tdd.ErrorCode;
+import io.hhplus.tdd.point.entity.PointHistory;
 import io.hhplus.tdd.point.entity.UserPoint;
 import io.hhplus.tdd.point.repository.PointHistoryRepository;
 import io.hhplus.tdd.point.repository.UserPointRepository;
 import io.hhplus.tdd.point.service.PointService;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -129,6 +131,23 @@ class PointServiceTest {
         long use = 200L;
         UserPoint userPoint2 = pointService.chargeOrUse(id, use, TransactionType.USE);
         assertEquals(4800L,  userPoint2.point());
+    }
+
+    @Test
+    @DisplayName("특정유저의 포인트 충전/사용 내역 조회")
+    void findPointHistoriesByUserId() {
+        long id = 1L;
+
+        when(pointHistoryRepository.selectAllByUserId(id))
+            .thenReturn(List.of(
+                new PointHistory(1,id,3000L,TransactionType.CHARGE,System.currentTimeMillis()),
+                new PointHistory(2,id,2500L,TransactionType.USE,System.currentTimeMillis())
+            ));
+
+        List<PointHistory> histories = pointService.findPointHistoriesByUserId(id);
+
+        assertEquals(2, histories.size());
+        assertEquals(id, histories.get(0).id());
     }
 
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -8,8 +8,10 @@ import static org.mockito.Mockito.when;
 
 import io.hhplus.tdd.CustomException;
 import io.hhplus.tdd.ErrorCode;
+import io.hhplus.tdd.point.entity.UserPoint;
 import io.hhplus.tdd.point.repository.PointHistoryRepository;
 import io.hhplus.tdd.point.repository.UserPointRepository;
+import io.hhplus.tdd.point.service.PointService;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
#### 포인트 사용 테스트코드 추가, 포인트 충전/사용 내역 조회기능 구현 및 테스트 코드 작성했습니다.

1. 멘토링 이후 Repository를 구현하는 것으로 수정하였습니다. 또한 테스트코드를 `mockito` 사용하도록 수정했습니다.

2. 포인트 충전 테스트코드에 포인트 사용하는 케이스도 추가하여 작성했습니다.
   -> 두가지를 연달아 테스트 하기위해 `when().thenAnswer()` 를 사용했습니다.

3. 포인트 충전/사용 내역 조회기능 구현 후 테스트 코드를 작성했습니다.
   -> 테스트 코드는 내역조회 함수가 리턴하는 리스트의 크기 및 userId가 일치하는지 확인합니다.